### PR TITLE
New German string for Master Firefox OS

### DIFF
--- a/de/LC_MESSAGES/django.po
+++ b/de/LC_MESSAGES/django.po
@@ -4815,7 +4815,7 @@ msgstr "Portugiesisch"
 
 #: masterfirefoxos/settings/base.py:210
 msgid "Romanian"
-msgstr ""
+msgstr "Rumänisch"
 
 #: masterfirefoxos/settings/base.py:211
 msgid "Russian"


### PR DESCRIPTION
Verbatim won’t let me, so I hope this works as well.
